### PR TITLE
Disable rules requiring Java package options to be set

### DIFF
--- a/rules/aip0191/aip0191.go
+++ b/rules/aip0191/aip0191.go
@@ -30,9 +30,9 @@ func AddRules(r lint.RuleRegistry) error {
 		filename,
 		fileLayout,
 		fileOptionConsistency,
-		javaMultipleFiles,
-		javaOuterClassname,
-		javaPackage,
+		//javaMultipleFiles,
+		//javaOuterClassname,
+		//javaPackage,
 		phpNamespace,
 		//protoPkg, //TODO: Shawn please make this not look at the path from Root.
 		rubyPackage,


### PR DESCRIPTION
As per [this Slack thread](https://commure.slack.com/archives/C02A2A6AP27/p1642793767001800), we don't want to configure package options ourselves, but rather use Buf's [managed mode](https://docs.buf.build/generate/managed-mode) to set these options for us. As these options will not be in the file, we don't want to lint for them.